### PR TITLE
Add one test for withdraw_confirm

### DIFF
--- a/tests/tests/withdraw_confirm.rs
+++ b/tests/tests/withdraw_confirm.rs
@@ -38,3 +38,44 @@ test_app_stream! {
 			res => r#"[]"#;
 	]
 }
+
+test_app_stream! {
+	name => withdraw_confirm_confirmations,
+	database => Database {
+		checked_withdraw_confirm: 0x00F5,
+		..Database::default()
+	},
+	mainnet =>
+		account => "0x0000000000000000000000000000000000000001",
+		confirmations => 12;
+	testnet =>
+		account => "0x0000000000000000000000000000000000000001",
+		confirmations => 12;
+	authorities =>
+		accounts => [
+			"0x0000000000000000000000000000000000000001",
+			"0x0000000000000000000000000000000000000002",
+		],
+		signatures => 1;
+	init => |app, db| create_withdraw_confirm(app, db).take(2),
+	expected => vec![0x1005, 0x1006],
+	mainnet_transport => [],
+	testnet_transport => [
+		"eth_blockNumber" =>
+			req => r#"[]"#,
+			res => r#""0x0100""#;
+		"eth_blockNumber" =>
+			req => r#"[]"#,
+			res => r#""0x1011""#;
+		"eth_getLogs" =>
+			req => r#"[{"address":["0x0000000000000000000000000000000000000000"],"fromBlock":"0xf6","limit":null,"toBlock":"0x1005","topics":[["0x884edad9ce6fa2440d8a54cc123490eb96d2768479d49ff9c7366125a9424364"],[],[],[]]}]"#,
+			res => r#"[]"#;
+		"eth_blockNumber" =>
+			req => r#"[]"#,
+			res => r#""0x1012""#;
+		"eth_getLogs" =>
+			req => r#"[{"address":["0x0000000000000000000000000000000000000000"],"fromBlock":"0x1006","limit":null,"toBlock":"0x1006","topics":[["0x884edad9ce6fa2440d8a54cc123490eb96d2768479d49ff9c7366125a9424364"],[],[],[]]}]"#,
+			res => r#"[]"#;
+	]
+}
+


### PR DESCRIPTION
I added one test for checking the amount of confirmations in withdraw_confirm, but I can't think of other things I could test with the current setup... could you give me some more pointers maybe?